### PR TITLE
Support putting two format specifiers next to each other

### DIFF
--- a/src/FSharpPlus/Parsing.fs
+++ b/src/FSharpPlus/Parsing.fs
@@ -176,9 +176,6 @@ module Parsing =
     /// Gets a tuple with the result of parsing each element of a formatted text. Returns None in case of failure.
     let inline trySscanf (pf: PrintfFormat<_,_,_,_,'``(T1 * T2 * ... * Tn)``>) : string -> '``(T1 * T2 * ... * Tn)`` option = getGroups pf >> TryParseArray.Invoke
 
-    /// Matches a formatted text with the result of parsing each element. Will not match in case of failure.
-    let inline (|Parsedf|_|) (pf: PrintfFormat<_,_,_,_,'``(T1 * T2 * ... * Tn)``>) : string -> '``(T1 * T2 * ... * Tn)`` option = trySscanf pf
-
     /// Gets a tuple with the result of parsing each element of a formatted text from the Console. Returns None in case of failure.
     let inline tryScanfn pf : '``(T1 * T2 * ... * Tn)`` option = trySscanf pf (Console.ReadLine ())
 

--- a/tests/FSharpPlus.Tests/Parsing.fs
+++ b/tests/FSharpPlus.Tests/Parsing.fs
@@ -107,6 +107,7 @@ module Parsing =
         let _zzz1 = sscanf "%%(%s)" "%(hello)"
         let (_x1,_y1,_z1) = sscanf "%s--%s-%s" "test--this-string"
         
+        let inline (|Parsedf|_|) pf = trySscanf pf
         match "ab" with Parsedf "%c" _ -> failwith "wrong match" | Parsedf "%c%c" ('a', 'b') -> () | _ -> failwith "didn't match"
         match "abc" with Parsedf "%c%c" ('a', 'b') -> failwith "wrong match" | Parsedf "%c%c%c%s" ('a', 'b', 'c', "") -> () | _ -> failwith "didn't match"
         match "(%hello)" with


### PR DESCRIPTION
Right now, trySscanf on e.g. `"%c%c"` won't work because all specifiers are translated to `(.*?)` under the hood.

Also added:
- ` ` format specifier consumes spaces to left
- `-` format specifier consumes spaces to right
- `+` format specifier consumes preceding plus for numbers
- `(|Scan|_|)` that turns `trySscanf` into an active pattern