### PR TITLE
ZipList implements IEnumerable's

### DIFF
--- a/src/FSharpPlus/Data/ZipList.fs
+++ b/src/FSharpPlus/Data/ZipList.fs
@@ -9,7 +9,7 @@ open FSharpPlus
 type ZipList<'s> = ZipList of 's seq with
     member this.Item n = let (ZipList s) = this in Seq.item n s
 
-    interface IEnumerable<'s> with member x.GetEnumerator () = (let (ZipList x) = x in x).GetEnumerator ()
+    interface System.Collections.Generic.IEnumerable<'s> with member x.GetEnumerator () = (let (ZipList x) = x in x).GetEnumerator ()
     interface System.Collections.IEnumerable with member x.GetEnumerator () = (let (ZipList x) = x in x).GetEnumerator () :> System.Collections.IEnumerator
 
 /// Basic operations on ZipList


### PR DESCRIPTION
Despite different semantics in some operations it shouldn't be a problem so in principle I see no reason why a ZipList shouldn't be treated as an IEnumerable.