### PR TITLE
docs: fix bifunctor bimap Result example

### DIFF
--- a/docsrc/content/abstraction-bifunctor.fsx
+++ b/docsrc/content/abstraction-bifunctor.fsx
@@ -97,6 +97,6 @@ open FSharpPlus
 let rInt10Str10 = bimap  int string (10.0, 10)
 
 
-let resOk11  = bimap  ((+) 1) string (Ok 10)
+let resOk11  = bimap  string ((+) 1) (Ok 10)
 let rStrTrue = first  string (true, 10)
 let rStr10   = second string (true, 10)


### PR DESCRIPTION
The original example `let resOk11 = bimap ((+) 1) string (Ok 10)` implied that the first function would be applied to the Result when it is `Ok` (returning `Ok 11`). However, this is backwards to the actual implementation:

```fsharp
let resOk11  = bimap  ((+) 1) string (Ok 10)
// val resOk11: Result<string,int> = Ok "10"
```

I have switched the order of the functions so that it produces the result expected (based on the name of the value binding `resOk11`):

```fsharp
let resOk11 = bimap string ((+) 1) (Ok 10)
// val resOk11: Result<int,string> = Ok 11
```