### PR TITLE
Add (|!>) operators

### DIFF
--- a/src/FSharpPlus/Operators.fs
+++ b/src/FSharpPlus/Operators.fs
@@ -175,6 +175,18 @@ module Operators =
     let inline iter (action: 'T->unit) (source: '``Functor<'T>``) : unit = Iterate.Invoke action source
 
     /// <summary>
+    /// Replaces a functor value with the supplied one, ignoring the original value.
+    /// </summary>
+    /// <category index="1">Functor</category>
+    let inline (|!>) (source: '``Functor<'T>``) (value: 'U) : '``Functor<'U>`` = Map.Invoke (fun _ -> value) source
+    
+    /// <summary>
+    /// Replaces a functor value with the supplied one, ignoring the original value.
+    /// </summary>
+    /// <category index="1">Functor</category>
+    let inline (<!|) (value: 'U) (source: '``Functor<'T>``) : '``Functor<'U>`` = Map.Invoke (fun _ -> value) source
+    
+    /// <summary>
     /// Un-zips (un-tuple) two functors.
     /// </summary>
     /// <category index="1">Functor</category>


### PR DESCRIPTION
These operators `(|!>)` and `(<!|)` ideally should be called `(!>)` and `(<!)` but the problem is that `(!>)` is unary and it turns out it will be the most used of the 2, because it's in the direction of typical F# pipes.

I think these operators are quite handy in real world code scenarios, when ignoring a value wrapped in a Task for example, then replacing it with another.