### PR TITLE
Enable SourceLink

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -31,12 +31,14 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: nupkg-${{ matrix.runs-on }}
-        path: ./bin/nupkg/*.nupkg
+        path: |
+          ./bin/nupkg/*.nupkg
+          ./bin/nupkg/*.snupkg
     - name: Push to GitHub Feed
       shell: bash
       run: |
-          for f in ./bin/nupkg/*.nupkg
+          for f in ./bin/nupkg/*.nupkg ./bin/nupkg/*.snupkg
           do
-            echo $f
-            dotnet nuget push $f -k ${{ secrets.GITHUB_TOKEN }} -s https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+            echo "$f"
+            dotnet nuget push "$f" -k ${{ secrets.GITHUB_TOKEN }} -s https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
           done

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,6 +13,8 @@
     <PackageIcon>logo.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>f# FSharp Applicative Monad MonadTransformer Arrow Overloading</PackageTags>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <VersionPrefix>1.9.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Version Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</Version>


### PR DESCRIPTION
Enables [SourceLink](https://github.com/dotnet/sourcelink) for improved downstream debugging experience.

The release pipeline now needs to also push the `.snupkg` alongside the `.nupkg`. I've given that a shot too, but you will need to verify that I did that right.