### PR TITLE
Align Async.Await with fslang-suggestions #840 (raise TaskCanceledException on cancel)

### DIFF
--- a/src/FSharpPlus/Extensions/Extensions.fs
+++ b/src/FSharpPlus/Extensions/Extensions.fs
@@ -163,13 +163,13 @@ module Extensions =
         /// at the point where the overall async is started.
         /// </remarks>
         static member Await (task: Task<'T>) : Async<'T> =
-            Async.FromContinuations (fun (sc, ec, cc) ->
+            Async.FromContinuations (fun (sc, ec, _) ->
                 task.ContinueWith (fun (task: Task<'T>) ->
                     if task.IsFaulted then
                         let e = Unchecked.nonNull task.Exception
                         if e.InnerExceptions.Count = 1 then ec e.InnerExceptions[0]
                         else ec e
-                    elif task.IsCanceled then cc (TaskCanceledException ())
+                    elif task.IsCanceled then ec (TaskCanceledException ())
                     else sc task.Result)
                 |> ignore)
         
@@ -190,13 +190,13 @@ module Extensions =
         /// at the point where the overall async is started.
         /// </remarks>
         static member Await (task: Task) : Async<unit> =
-            Async.FromContinuations (fun (sc, ec, cc) ->
+            Async.FromContinuations (fun (sc, ec, _) ->
                 task.ContinueWith (fun (task: Task) ->
                     if task.IsFaulted then
                         let e = Unchecked.nonNull task.Exception
                         if e.InnerExceptions.Count = 1 then ec e.InnerExceptions[0]
                         else ec e
-                    elif task.IsCanceled then cc (TaskCanceledException ())
+                    elif task.IsCanceled then ec (TaskCanceledException ())
                     else sc ())
                 |> ignore)
         

--- a/tests/FSharpPlus.Tests/Asyncs.fs
+++ b/tests/FSharpPlus.Tests/Asyncs.fs
@@ -41,8 +41,9 @@ module Async =
             let t2 = createAsync true 0 2
             let t3 = createAsync true 0 3
 
-            let c = new CancellationToken true
-            let t4 = Task.FromCanceled<int> c |> Async.Await
+            // A genuinely cancelled async: Async.Await no longer surfaces a cancelled Task as a
+            // cancellation, it raises TaskCanceledException (fslang-suggestions #840).
+            let t4 : Async<int> = Async.FromContinuations (fun (_, _, cc) -> cc (OperationCanceledException ()))
 
             let t5 = createAsync false 0 5
             let t6 = createAsync false 0 6
@@ -71,8 +72,9 @@ module Async =
             let t2 = createAsync true 10 2
             let t3 = createAsync true 30 3
 
-            let c = new CancellationToken true
-            let t4 = Task.FromCanceled<int> c |> Async.Await
+            // A genuinely cancelled async: Async.Await no longer surfaces a cancelled Task as a
+            // cancellation, it raises TaskCanceledException (fslang-suggestions #840).
+            let t4 : Async<int> = Async.FromContinuations (fun (_, _, cc) -> cc (OperationCanceledException ()))
 
             let t5 = createAsync false 20 5
             let t6 = createAsync false 10 6

--- a/tests/FSharpPlus.Tests/Task.fs
+++ b/tests/FSharpPlus.Tests/Task.fs
@@ -273,6 +273,30 @@ module Task =
             Assert.AreEqual (e0, e1, "Original exception is not the same as that extracted from the Async")
             Assert.AreEqual (e1, e2, "The exception extracted from the Async is not the same as that extracted from the roundtripped Task")
 
+        [<Test>]
+        let awaitOfCancelledTaskRaisesTaskCanceledException () =
+            // A cancelled Task is surfaced through the exception continuation as a TaskCanceledException, so it can be
+            // caught with an ordinary try/with around the Await, matching C# await (fslang-suggestions #840).
+            let ct = CancellationToken true
+
+            let caughtGeneric =
+                async {
+                    try
+                        let! _ = Async.Await (Task.FromCanceled<int> ct)
+                        return false
+                    with :? TaskCanceledException -> return true }
+                |> Async.RunSynchronously
+            Assert.IsTrue (caughtGeneric, "Await of a cancelled Task<'T> should raise a TaskCanceledException catchable by try/with")
+
+            let caughtNonGeneric =
+                async {
+                    try
+                        do! Async.Await (Task.FromCanceled ct)
+                        return false
+                    with :? TaskCanceledException -> return true }
+                |> Async.RunSynchronously
+            Assert.IsTrue (caughtNonGeneric, "Await of a cancelled Task should raise a TaskCanceledException catchable by try/with")
+
     
     // This module contains tests for ComputationExpression not covered by the below TaskBuilderTests module
     module ComputationExpressionTests =


### PR DESCRIPTION
Aligns `Async.Await` with [fslang-suggestions #840](https://github.com/fsharp/fslang-suggestions/issues/840), as requested in [dotnet/fsharp#19785 (comment)](https://github.com/dotnet/fsharp/pull/19785#issuecomment-5200878789) and tracked by #676.

## What

On cancellation, both `Await` overloads (`Task<'T>` and `Task`) now call the **exception continuation** with a `TaskCanceledException` (`ec`) instead of the **cancellation continuation** (`cc`):

```fsharp
-  elif task.IsCanceled then cc (TaskCanceledException ())
+  elif task.IsCanceled then ec (TaskCanceledException ())
```

## Why

With `cc`, a cancelled `Task` propagated as an async cancellation, so a `try ... with :? TaskCanceledException ->` placed around the `Await` would **not** catch it. With `ec` it is surfaced as an ordinary exception, catchable locally — matching C# `await` and every `AwaitTaskCorrect`-derived implementation. The doc comment already described this behaviour.

Note: `Async.map2`/`map3`/`zip` build on `Await`, so a purely-cancelled input now surfaces as a `TaskCanceledException` rather than a cancellation. Where cancellation is combined with a fault, the fault still wins (cancellation dropped in `Task.map*` before reaching `Await`).

## Tests

- `Asyncs.fs` zip tests build their cancellation input directly (they previously relied on `Await` of a cancelled `Task` yielding a cancellation).
- Added `Task.fs` coverage asserting a cancelled `Task`/`Task<'T>` await raises a `TaskCanceledException` catchable by `try/with`.

> Based on `tgro-fsharp10`, so the diff against `master` also includes that branch's net10/net11 build-tracking work.
